### PR TITLE
Migrate plugin to npm for cordova cli v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,33 +15,17 @@ Cordova/Phonegap 3.0 or greater is required.
 
 # Installing
 
-Logit.io can be installed with:
-
-[Cordova CLI](http://cordova.apache.org/docs/en/edge/guide_cli_index.md.html):
+**Latest published version on npm (with Cordova CLI >= 5.0.0)**
 
 ```
-$ cordova plugin add io.logit.cordova
+cordova plugin add cordova-plugin-logit
 ```
 
-[PhoneGap CLI](http://docs.phonegap.com/en/edge/guide_cli_index.md.html):
+**Latest version from GitHub**
 
 ```
-$ phonegap plugin add io.logit.cordova
+cordova plugin add https://github.com/logit-io/cordova-logitio.git
 ```
-
-[Cordova Plugman](https://github.com/apache/cordova-plugman):
-
-
-```
-$ plugman install --plugin io.logit.cordova --platform <ios|amazon-fireos|android|blackberry10|wp8> --project platforms/<platform> --plugins_dir plugins
-```
-
-For example, to install for Android:
-
-```
-$ plugman install --plugin io.logit.cordova --platform android --project platforms/android --plugins_dir plugins
-```
-
 
 # Using the plugin
 

--- a/package.json
+++ b/package.json
@@ -1,24 +1,51 @@
 {
-    "name": "io.logit.cordova",
-    "cordova_name": "Logit.io Plugin",
-    "version": "0.1.2",
-    "description": "Cordova plugin to integrate with logit.io logging system",
-    "license": "MIT License",
-    "repo": "https://github.com/logit-io/cordova-logitio.git",
-    "keywords": ["cordova","phonegap","ios","android","logit","io","logging","error tracking","debugging"],
+  "name": "cordova-plugin-logit",
+  "version": "0.2.0",
+  "description": "Cordova plugin to integrate with logit.io logging system",
+  "cordova": {
+    "id": "cordova-plugin-logit",
     "platforms": [
-        "android",
-        "amazon-fireos",
-        "ubuntu",
-        "ios",
-        "wp7",
-        "wp8",
-        "windows8"
-    ],
-    "engines": [
-        {
-            "name": "cordova",
-            "version": ">=3.0.0"
-        }
+      "firefoxos",
+      "tizen",
+      "android",
+      "amazon-fireos",
+      "ubuntu",
+      "ios",
+      "blackberry10",
+      "wp7",
+      "wp8",
+      "windows8",
+      "windows",
+      "browser"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/logit-io/cordova-logitio.git"
+  },
+  "keywords": [
+    "cordova",
+    "phonegap",
+    "ios",
+    "android",
+    "logit",
+    "io",
+    "logging",
+    "error",
+    "tracking",
+    "debugging",
+    "ecosystem:cordova"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Dave Alden",
+  "license": "MIT License",
+  "bugs": {
+    "url": "https://github.com/logit-io/cordova-logitio/issues"
+  },
+  "homepage": "https://github.com/logit-io/cordova-logitio#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-id="io.logit.cordova"
-version="0.1.2">
+<?xml version='1.0' encoding='UTF-8'?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-logit" version="0.2.0">
     <engines>
         <engine name="cordova" version=">=3.0.0" />
     </engines>


### PR DESCRIPTION
Update the package.json and readme installation instructions as per the guidance for the recent release of the Cordova CLI (v5.0.0) - more information [here](https://cordova.apache.org/announcements/2015/04/21/plugins-release-and-move-to-npm.html).

Also bumped plugin version to 0.2.0.

`npm publish` will be required after merge.
